### PR TITLE
Don't set debug signal handler on Windows

### DIFF
--- a/bin/predict.py
+++ b/bin/predict.py
@@ -38,7 +38,8 @@ LOGGER = logging.getLogger(__name__)
 @hydra.main(config_path='../configs/prediction', config_name='default.yaml')
 def main(predict_config: OmegaConf):
     try:
-        register_debug_signal_handlers()  # kill -10 <pid> will result in traceback dumped into log
+        if sys.platform != 'win32':
+            register_debug_signal_handlers()  # kill -10 <pid> will result in traceback dumped into log
 
         device = torch.device(predict_config.device)
 

--- a/bin/predict_inner_features.py
+++ b/bin/predict_inner_features.py
@@ -38,7 +38,8 @@ LOGGER = logging.getLogger(__name__)
 @hydra.main(config_path='../configs/prediction', config_name='default_inner_features.yaml')
 def main(predict_config: OmegaConf):
     try:
-        register_debug_signal_handlers()  # kill -10 <pid> will result in traceback dumped into log
+        if sys.platform != 'win32':
+            register_debug_signal_handlers()  # kill -10 <pid> will result in traceback dumped into log
 
         device = torch.device(predict_config.device)
 

--- a/bin/to_jit.py
+++ b/bin/to_jit.py
@@ -27,7 +27,8 @@ class JITWrapper(nn.Module):
 
 @hydra.main(config_path="../configs/prediction", config_name="default.yaml")
 def main(predict_config: OmegaConf):
-    register_debug_signal_handlers()  # kill -10 <pid> will result in traceback dumped into log
+    if sys.platform != 'win32':
+        register_debug_signal_handlers()  # kill -10 <pid> will result in traceback dumped into log
 
     train_config_path = os.path.join(predict_config.model.path, "config.yaml")
     with open(train_config_path, "r") as f:

--- a/bin/train.py
+++ b/bin/train.py
@@ -31,7 +31,8 @@ def main(config: OmegaConf):
     try:
         need_set_deterministic = handle_deterministic_config(config)
 
-        register_debug_signal_handlers()  # kill -10 <pid> will result in traceback dumped into log
+        if sys.platform != 'win32':
+            register_debug_signal_handlers()  # kill -10 <pid> will result in traceback dumped into log
 
         is_in_ddp_subprocess = handle_ddp_parent_process()
 


### PR DESCRIPTION
Handling the `SIGUSR1` signal is not supported on Windows. Therefore, some of the scripts (such as `predict.py`) don't run out of the box. As the signal handler is only used for debugging, this PR disables it when running on Windows.

Related to #150.