### PR TITLE
Fix: docker base image url

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.2-runtime-ubuntu18.04
+FROM nvcr.io/nvidia/cuda:10.2-runtime-ubuntu18.04
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/docker/Dockerfile-cuda111
+++ b/docker/Dockerfile-cuda111
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.1-runtime-ubuntu18.04
+FROM nvcr.io/nvidia/cuda:11.1.1-runtime-ubuntu18.04
 
 RUN apt-get update && \
     apt-get upgrade -y && \


### PR DESCRIPTION
The Dockerfile's Base Image urls are no longer exist in Docker Hub.

But i found the same image in nvcr.io.

So, I replaced the urls.
 - nvidia/cuda:10.2-runtime-ubuntu18.04 -> nvcr.io/nvidia/cuda:10.2-runtime-ubuntu18.04
 - nvidia/cuda:11.1.1-runtime-ubuntu18.04 -> nvcr.io/nvidia/cuda:11.1.1-runtime-ubuntu18.04

close issue #263